### PR TITLE
修改准备扩展节点资源目录

### DIFF
--- a/3.x/zh_CN/docs/tutorial/air/expand_node.md
+++ b/3.x/zh_CN/docs/tutorial/air/expand_node.md
@@ -33,7 +33,7 @@ Air版本区块链扩容时，需要提前准备证书和配置文件，用于�
 
 ```shell
 # 进入操作目录(Note: 进行本操作之前，请参考【搭建第一个区块链网络节点】部署一条Air版FISCO BCOS区块链)
-$ cd ~/fisco/nodes
+$ cd ~/fisco
 
 # 创建扩容配置存放目录
 $ mkdir config


### PR DESCRIPTION
准备扩容所需文件时进入目录为fisco而非nodes目录（否则后续准备全部有误），修改后完成所有操作